### PR TITLE
output grouping stats to a file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/neilgarb/covertool
 
-go 1.20
+go 1.21
 
 require golang.org/x/tools v0.9.1


### PR DESCRIPTION
Specify a file to output grouped stats to with -out 

example usage:
```
covertool -profile=cover.out -grouping='(.*)' -out files.out
```
group each file
```
covertool -profile=cover.out -grouping='(.*)/[^/]*\.go' -out packages.out
```
groups each package